### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -19,7 +19,8 @@ def index():
 
     elif author:
         cursor.execute(
-            "SELECT * FROM books WHERE author LIKE '%" + author + "%'"
+            "SELECT * FROM books WHERE author LIKE ?", 
+            ('%' + author + '%',)
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
Potential fix for [https://github.com/gauravjakhar/skills-introduction-to-codeql/security/code-scanning/2](https://github.com/gauravjakhar/skills-introduction-to-codeql/security/code-scanning/2)

To fix this issue, the SQL query should not directly concatenate user-controlled input. Instead, it should use parameterized queries, which allow the database adapter to safely handle and escape user input. In Python's DB API (such as sqlite3 or MySQLdb or psycopg2), queries should use `?` or `%s` placeholders rather than directly inserting values into the string.  
In this particular code, the pattern `'author LIKE '%...%'` can still be constructed safely by using query parameters. Instead of concatenating, pass the pattern as a parameter:  
Change  
```python
cursor.execute("SELECT * FROM books WHERE author LIKE '%" + author + "%'")
```
to  
```python
cursor.execute("SELECT * FROM books WHERE author LIKE %s", ("%" + author + "%",))
```
or, if using SQLite,  
```python
cursor.execute("SELECT * FROM books WHERE author LIKE ?", ("%" + author + "%",))
```
(Depending on the underlying database and library—Code should use the appropriate parameter style for the database library in use.)

Since the code is shared via `server/routes.py` and uses `cursor` from `server.webapp`, we do not see implementation specifics about the cursor. The most common and safe choice is to use DB-API/Python parameterization (with `?`), which works for SQLite, and adjust if it is a different backend.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
